### PR TITLE
bug in stomp_socket

### DIFF
--- a/lib/stomp_socket.js
+++ b/lib/stomp_socket.js
@@ -10,21 +10,30 @@ function StompSocket(args) {
   this.ssl_options = args.ssl_options;
   this.socket = new net.Socket();
   this.stompParser = new StompParse();
+  this.bufferLocked = false;
+  this.buffer = '';
 };
 
 StompSocket.prototype = new process.EventEmitter();
 
 StompSocket.prototype.prepareDataForParsing = function(buffer) {
-  var frames = buffer.split('\0\n');
-
-  if (frames.length == 1) {
-    frames = buffer.split('\0');
+  if (this.bufferLocked) {
+    process.nextTick(this.prepareDataForParsing.bind(this));
   }
+  this.bufferLocked = true;
+
+  var frames = this.buffer.split('\0');
 
   if (frames.length == 1) return;
-  buffer = frames.pop();
-  return frames;
+  this.buffer = frames.pop();
 
+  this.bufferLocked = false;
+
+  for (var i = 0; i < frames.length; i++) {
+    frames[i] = frames[i].replace(/^\n+/, '');
+  }
+
+  return frames;
 }
 
 StompSocket.prototype.handleData = function(chunk) {


### PR DESCRIPTION
StompSocket.prepareDataForParsing behaved badly when the chunk boundary didn't coincide with the frame boundary as you were not keeping a running buffer.  I modified the code for my own purposes (I'm testing the viability of using ActiveMQ with NodeJS) but thought you might like the fix.

You also weren't handling the case that there may be more than one new line after the null byte.  I don't really like my solution either but it works.

Other than that, everything is working smoothly.  Great job!
